### PR TITLE
Display Active Incidents

### DIFF
--- a/apps/web/assets/elm/Entities/Incident.elm
+++ b/apps/web/assets/elm/Entities/Incident.elm
@@ -4,10 +4,19 @@ import Json.Decode as Decode
 import Json.Decode.Pipeline as Pipeline
 
 
+type Alert
+    = Honeycomb { title : String, description : String, url : String }
+    | Bugsnag { title : String, stackTrace : String, url : String }
+    | Unknown
+
+
 type alias Incident =
     { id : String
     , title : String
     , status : String
+    , url : String
+    , service : String
+    , alert : Alert
     }
 
 
@@ -15,10 +24,38 @@ decoder : Decode.Decoder Incident
 decoder =
     Decode.succeed Incident
         |> Pipeline.required "id" Decode.string
-        |> Pipeline.required "name" Decode.string
+        |> Pipeline.required "title" Decode.string
         |> Pipeline.required "status" Decode.string
+        |> Pipeline.required "html_url" Decode.string
+        |> Pipeline.required "service_summary" Decode.string
+        |> Pipeline.required "alert" alertDecoder
 
 
 listDecoder : Decode.Decoder (List Incident)
 listDecoder =
     Decode.list decoder
+
+
+alertDecoder : Decode.Decoder Alert
+alertDecoder =
+    Decode.at [ "body", "cef_details", "client" ] Decode.string
+        |> Decode.andThen decodeAlert
+
+
+decodeAlert : String -> Decode.Decoder Alert
+decodeAlert client =
+    case client of
+        "Honeycomb Triggers" ->
+            Decode.succeed (\x y z -> Honeycomb { title = x, description = y, url = z })
+                |> Pipeline.optionalAt [ "body", "cef_details", "details", "trigger_description" ] Decode.string ""
+                |> Pipeline.requiredAt [ "body", "cef_details", "details", "description" ] Decode.string
+                |> Pipeline.requiredAt [ "body", "cef_details", "client_url" ] Decode.string
+
+        "Bugsnag" ->
+            Decode.succeed (\x y z -> Bugsnag { title = x, stackTrace = y, url = z })
+                |> Pipeline.requiredAt [ "body", "cef_details", "details", "class" ] Decode.string
+                |> Pipeline.requiredAt [ "body", "cef_details", "details", "stackTrace" ] Decode.string
+                |> Pipeline.requiredAt [ "body", "cef_details", "client_url" ] Decode.string
+
+        _ ->
+            Decode.succeed Unknown

--- a/apps/web/assets/elm/Entities/Incident.elm
+++ b/apps/web/assets/elm/Entities/Incident.elm
@@ -1,0 +1,24 @@
+module Entities.Incident exposing (Incident, decoder, listDecoder)
+
+import Json.Decode as Decode
+import Json.Decode.Pipeline as Pipeline
+
+
+type alias Incident =
+    { id : String
+    , title : String
+    , status : String
+    }
+
+
+decoder : Decode.Decoder Incident
+decoder =
+    Decode.succeed Incident
+        |> Pipeline.required "id" Decode.string
+        |> Pipeline.required "name" Decode.string
+        |> Pipeline.required "status" Decode.string
+
+
+listDecoder : Decode.Decoder (List Incident)
+listDecoder =
+    Decode.list decoder

--- a/apps/web/assets/elm/Main.elm
+++ b/apps/web/assets/elm/Main.elm
@@ -1,6 +1,7 @@
 module Main exposing (main)
 
 import Browser
+import Entities.Incident exposing (Incident)
 import Entities.Subscription exposing (Subscription)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -8,12 +9,6 @@ import Http
 import Requests.Subscriptions
 import Time
 import Views.Subscriptions
-
-
-type alias Incident =
-    { id : String
-    , title : String
-    }
 
 
 type alias Model =
@@ -32,7 +27,7 @@ type Msg
     | SubscriptionUpdated (Result Http.Error (List String))
     | SubscriptionChange String Bool
     | GotSubscriptions (Result Http.Error (List Subscription))
-    | Ping Time.Posix
+    | PollForIncidents
 
 
 init : Flags -> ( Model, Cmd Msg )
@@ -44,7 +39,7 @@ init flags =
             , csrfToken = flags.csrfToken
             }
     in
-    ( model, Requests.Subscriptions.get GotSubscriptions )
+    ( model, Cmd.batch [Requests.Subscriptions.get GotSubscriptions )
 
 
 view : Model -> Html Msg
@@ -113,7 +108,7 @@ update msg model =
             in
             ( { model | subscriptions = newSubscriptions }, Cmd.none )
 
-        Ping _ ->
+        PollForIncidents ->
             ( Debug.log "ping" model, Cmd.none )
 
         _ ->
@@ -122,7 +117,7 @@ update msg model =
 
 elmSubscriptions : Model -> Sub Msg
 elmSubscriptions model =
-    Time.every 1000 Ping
+    Time.every 5000 (\x -> PollForIncidents)
 
 
 main : Program Flags Model Msg

--- a/apps/web/assets/elm/Requests/Incidents.elm
+++ b/apps/web/assets/elm/Requests/Incidents.elm
@@ -1,0 +1,14 @@
+module Requests.Incidents exposing (get)
+
+import Entities.Incident exposing (Incident, listDecoder)
+import Http
+import Json.Decode as Decode
+import Json.Encode as Encode
+
+
+get : (Result Http.Error (List Incident) -> msg) -> Cmd msg
+get msg =
+    Http.get
+        { url = "/incidents"
+        , expect = Http.expectJson msg listDecoder
+        }

--- a/apps/web/assets/elm/Views/Incidents.elm
+++ b/apps/web/assets/elm/Views/Incidents.elm
@@ -1,0 +1,13 @@
+module Views.Incidents exposing (render)
+
+import Entities.Incident exposing (Incident)
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+
+
+render : Incident -> Html msg
+render incident =
+    div [ class "incident", class ("incident--" ++ incident.status) ]
+        [ h4 [ class "incident__title" ] [ a [ href incident.url ] [ text incident.title ] ]
+        ]

--- a/apps/web/assets/stylesheets/application.scss
+++ b/apps/web/assets/stylesheets/application.scss
@@ -10,15 +10,57 @@ html {
 
 body {
   margin: auto;
+  width: 100%;
 }
 
 .subscription {
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
+}
+
+.subscriptions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .subscription label {
   margin-right: 4px;
+}
+
+.incidents {
+  min-width: 400px;
+  max-width: 800px;
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.incident {
+  margin: 4px;
+  padding: 4px;
+}
+
+.incident--triggered {
+  border-left: red solid 3px;
+}
+
+.incident--acknowledged {
+  border-left: orange solid 3px;
+}
+
+.incident--resolved {
+  border-left: green solid;
+}
+
+.incident__title {
+  margin-top: 0;
+  margin-bottom: 0;
+
+  a {
+    text-decoration: none;
+  }
+
+  a:visited {}
 }

--- a/apps/web/config/routes.rb
+++ b/apps/web/config/routes.rb
@@ -12,5 +12,5 @@ get '/logout', to: 'home#logout'
 get '/ping', to: 'json#pong'
 get '/subscriptions', to: 'json#fetch_subscriptions'
 patch '/subscriptions', to: 'json#update_subscription'
-
+get '/incidents', to: 'json#fetch_incidents'
 patch '/organisation', to: 'organisations#update'

--- a/apps/web/controllers/json/fetch_incidents.rb
+++ b/apps/web/controllers/json/fetch_incidents.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Web
+  module Controllers
+    module Json
+      class FetchIncidents
+        include Web::Action
+
+        before :authenticate_user!
+
+        def call(*)
+          organisation = OrganisationRepository.new.find(current_user.organisation_id)
+          operation = Slackerduty::Operations::FetchIncidents.new.call(organisation)
+          headers['Content-Type'] = 'application/json'
+
+          if operation.success?
+            self.body = operation.incidents.to_json
+          else
+            self.body = { error: operation.error }.to_json
+            self.status = 400
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -28,21 +28,7 @@ Hanami.configure do
   middleware.use Hanami::Middleware::BodyParser, :json
 
   model do
-    ##
-    # Database adapter
-    #
-    # Available options:
-    #
-    #  * SQL adapter
-    #    adapter :sql, 'sqlite://db/slackerduty_development.sqlite3'
-    #    adapter :sql, 'postgresql://localhost/slackerduty_development'
-    #    adapter :sql, 'mysql://localhost/slackerduty_development'
-    #
     adapter :sql, ENV.fetch('DATABASE_URL')
-
-    ##
-    # Migrations
-    #
     migrations 'db/migrations'
     schema     'db/schema.sql'
   end

--- a/elm.json
+++ b/elm.json
@@ -11,12 +11,12 @@
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
-            "elm/json": "1.1.3"
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
-            "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }

--- a/lib/slackerduty/operations/fetch_incidents.rb
+++ b/lib/slackerduty/operations/fetch_incidents.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'hanami/interactor'
+
+module Slackerduty
+  module Operations
+    class FetchIncidents
+      include Hanami::Interactor
+
+      expose(:incidents)
+
+      attr_reader :repository
+
+      def initialize(repository: IncidentRepository.new)
+        @repository = repository
+      end
+
+      def call(organisation)
+        @incidents = repository.active(organisation).to_a
+      end
+    end
+  end
+end

--- a/lib/slackerduty/repositories/incident_repository.rb
+++ b/lib/slackerduty/repositories/incident_repository.rb
@@ -2,6 +2,6 @@
 
 class IncidentRepository < Hanami::Repository
   def active(organisation)
-    incidents.where(status: ['triggered', 'acknowledged'], organisation_id: organisation.id)
+    incidents.where(status: %w[triggered acknowledged], organisation_id: organisation.id)
   end
 end

--- a/lib/slackerduty/repositories/incident_repository.rb
+++ b/lib/slackerduty/repositories/incident_repository.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class IncidentRepository < Hanami::Repository
+  def active(organisation)
+    incidents.where(status: ['triggered', 'acknowledged'], organisation_id: organisation.id)
+  end
 end


### PR DESCRIPTION
Related: #4 

Front-end polls `/incidents` every 5 seconds & displays.

`/incidents` should return the list of all open (i.e. not resolved) incidents

<img width="1552" alt="Screen Shot 2019-06-23 at 15 36 57" src="https://user-images.githubusercontent.com/7707413/59977715-c60b3100-95cc-11e9-8658-d9e83ef8f02a.png">
