### PR TITLE
Enqueue Workers::ProcessPagerDutyEvent with 5 second delay

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,6 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 25
+
+RSpec/ExampleLength:
+  Max: 10

--- a/apps/api/controllers/webhooks/pager_duty.rb
+++ b/apps/api/controllers/webhooks/pager_duty.rb
@@ -27,7 +27,8 @@ module Api
           token = params[:pager_duty_token]
 
           params[:messages].each do |message|
-            Slackerduty::Workers::ProcessPagerDutyEvent.perform_async(
+            Slackerduty::Workers::ProcessPagerDutyEvent.perform_in(
+              5,
               message: message,
               token: token
             )

--- a/spec/api/controllers/webhooks/pager_duty_spec.rb
+++ b/spec/api/controllers/webhooks/pager_duty_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Api::Controllers::Webhooks::PagerDuty, type: :action do
 
     before do
       allow(Slackerduty::Workers::ProcessPagerDutyEvent).to(
-        receive(:perform_async)
+        receive(:perform_in)
       )
     end
 
@@ -124,14 +124,15 @@ RSpec.describe Api::Controllers::Webhooks::PagerDuty, type: :action do
       action.call(params)
 
       expect(Slackerduty::Workers::ProcessPagerDutyEvent).to(
-        have_received(:perform_async).twice
+        have_received(:perform_in).twice
       )
     end
 
     it 'enqueues a job for the first message' do
       action.call(params)
 
-      expect(Slackerduty::Workers::ProcessPagerDutyEvent).to have_received(:perform_async).with(
+      expect(Slackerduty::Workers::ProcessPagerDutyEvent).to have_received(:perform_in).with(
+        5,
         message: message_one.deep_symbolize_keys,
         token: token
       )
@@ -140,7 +141,8 @@ RSpec.describe Api::Controllers::Webhooks::PagerDuty, type: :action do
     it 'enqueues a job for the second message' do
       action.call(params)
 
-      expect(Slackerduty::Workers::ProcessPagerDutyEvent).to have_received(:perform_async).with(
+      expect(Slackerduty::Workers::ProcessPagerDutyEvent).to have_received(:perform_in).with(
+        5,
         message: message_two.deep_symbolize_keys,
         token: token
       )


### PR DESCRIPTION
Sometimes slackerduty will fetch a PagerDuty incident, before PagerDuty
has associated the alert to it, this results in not being able to show
richer information related to an incident.

This isn't an ideal solution, but it is easy. We could alternatively
enqueue something to update an incident after a couple of seconds.